### PR TITLE
Allow faraday 1.x

### DIFF
--- a/chilling_effects.gemspec
+++ b/chilling_effects.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'chilling_effects'
-  s.version     = '0.0.2.ksr1'
+  s.version     = '0.0.2.ksr2'
   s.license     = 'GPL-2'
   s.summary     = "A Ruby gem to interact with the Chilling Effects API"
   s.description = "A Ruby gem to interact with the Chilling Effects API."
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   ]
   s.homepage    = 'https://github.com/benbalter/chilling_effects'
 
-  s.add_runtime_dependency "faraday", "~> 0.9"
-  s.add_runtime_dependency "faraday_middleware", "~> 0.9"
+  s.add_runtime_dependency "faraday", ">= 0.9", "< 2.0.0"
+  s.add_runtime_dependency "faraday_middleware", ">= 0.9", "< 2.0.0"
   s.add_runtime_dependency "hashie", "~> 3.4"
   s.add_runtime_dependency "activemodel", ">= 4"
   s.add_runtime_dependency "activesupport", ">= 4"


### PR DESCRIPTION
This change won't have any immediate effect on the Kickstarter repository, but it will unblock us from upgrading the `faraday` and `faraday_middleware` gems. Testing to ensure no compatibility is broken will occur at that stage, as this PR only makes the newer versions available and doesn't switch us to them.